### PR TITLE
Use gauge instead of criterion for benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .ghc.environment.*
 dist-newstyle/
 dist/
+*.dyn_hi
+*.hi
+*.o

--- a/bench/main.hs
+++ b/bench/main.hs
@@ -2,8 +2,7 @@
 {-# language TypeFamilies #-}
 module Main where
 
-import Criterion
-import Criterion.Main
+import Gauge
 import Control.Newtype.Generics
 import Data.Coerce
 import Data.Foldable (foldMap)

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -51,7 +51,7 @@ benchmark bench
   main-is:            main.hs
   hs-source-dirs:     bench
   build-depends:      base >= 4.7
-                    , criterion
+                    , gauge
                     , newtype-generics
                     , semigroups
   ghc-options:        -O2


### PR DESCRIPTION
This speeds up the build.
Fixes #3.