### PR TITLE
Support GHC 8.8

### DIFF
--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -26,7 +26,7 @@ Tested-with:
 Library
   Exposed-modules:     Control.Newtype
                      , Control.Newtype.Generics
-  Build-depends:       base >= 4.6 && < 4.13
+  Build-depends:       base >= 4.6 && < 4.14
                      , transformers < 0.6
   Ghc-options: -Wall
   default-language:   Haskell2010


### PR DESCRIPTION
Pardon an automatically-posted pull request; this is a part of [Operation Vanguard](https://github.com/haskell-vanguard/haskell-vanguard). Note that this does not guarantee that tests and benchmarks are buildable.