### PR TITLE
Fix/ghc 9.2

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -30,6 +30,12 @@ jobs:
     strategy:
       matrix:
         include:
+          - compiler: ghc-9.2.1
+            allow-failure: false
+            compilerKind: ghc
+            compilerVersion: 9.2.1
+            setup-method: ghcup
+            allow-failure: false
           - ghc: 9.0.1
             allow-failure: false
           - ghc: 8.10.4

--- a/Control/Newtype/Generics.hs
+++ b/Control/Newtype/Generics.hs
@@ -65,7 +65,7 @@ import Data.Kind (Type)
 import Data.Monoid
 import Data.Ord
 import qualified Data.Semigroup
-import Data.Semigroup (Min(..), Max(..), WrappedMonoid(..), Option(..))
+import Data.Semigroup (Min(..), Max(..), WrappedMonoid(..))
 import GHC.Generics
 {-import Generics.Deriving-}
 
@@ -365,9 +365,3 @@ instance Newtype (WrappedMonoid m) where
   type O (WrappedMonoid m) = m
   pack = WrapMonoid
   unpack (WrapMonoid m) = m
-
--- | @since 0.5.1
-instance Newtype (Option a) where
-  type O (Option a) = Maybe a
-  pack = Option
-  unpack (Option x) = x

--- a/Control/Newtype/Generics.hs
+++ b/Control/Newtype/Generics.hs
@@ -65,7 +65,11 @@ import Data.Kind (Type)
 import Data.Monoid
 import Data.Ord
 import qualified Data.Semigroup
+#if MIN_VERSION_base(4,16,0)
 import Data.Semigroup (Min(..), Max(..), WrappedMonoid(..))
+#else
+import Data.Semigroup (Min(..), Max(..), WrappedMonoid(..),Option(..))
+#endif
 import GHC.Generics
 {-import Generics.Deriving-}
 
@@ -365,3 +369,11 @@ instance Newtype (WrappedMonoid m) where
   type O (WrappedMonoid m) = m
   pack = WrapMonoid
   unpack (WrapMonoid m) = m
+
+#if !MIN_VERSION_base(4,16,0)
+-- | @since 0.5.1
+instance Newtype (Option a) where
+  type O (Option a) = Maybe a
+  pack = Option
+  unpack (Option x) = x
+#endif

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -1,5 +1,5 @@
 Name:                newtype-generics
-Version:             0.7
+Version:             0.6.1
 Synopsis:            A typeclass and set of functions for working with newtypes
 Description:         Per Conor McBride, the Newtype typeclass represents the packing and unpacking of a newtype,
                      and allows you to operate under that newtype with functions such as ala.
@@ -15,6 +15,7 @@ Build-type:          Simple
 Extra-source-files:  CHANGELOG.md
 Cabal-version:       >=1.10
 Tested-with:
+  GHC==9.2.1,
   GHC==9.0.1,
   GHC==8.10.4,
   GHC==8.8.4,
@@ -25,7 +26,7 @@ Tested-with:
 
 Library
   Exposed-modules:     Control.Newtype.Generics
-  Build-depends:       base >= 4.9 && < 4.16
+  Build-depends:       base >= 4.9 && < 4.17
                      , transformers < 0.6
   Ghc-options: -Wall
   default-language:   Haskell2010

--- a/newtype-generics.cabal
+++ b/newtype-generics.cabal
@@ -1,5 +1,5 @@
 Name:                newtype-generics
-Version:             0.6
+Version:             0.7
 Synopsis:            A typeclass and set of functions for working with newtypes
 Description:         Per Conor McBride, the Newtype typeclass represents the packing and unpacking of a newtype,
                      and allows you to operate under that newtype with functions such as ala.


### PR DESCRIPTION
Removed the 'option' instance since option is not just deprecated but gone totally from GHC.  Bumped the version too.